### PR TITLE
Bug fix: relative URI starting with a slash

### DIFF
--- a/lib/exonerate/tools.ex
+++ b/lib/exonerate/tools.ex
@@ -306,18 +306,27 @@ defmodule Exonerate.Tools do
         base_path = path || "/"
         dest_path = target.path || ""
 
-        if String.ends_with?(path, "/") do
-          %URI{
-            path: Path.join(base_path, dest_path),
-            query: target.query,
-            fragment: target.fragment
-          }
-        else
-          %URI{
-            path: Path.join(Path.dirname(base_path), dest_path),
-            query: target.query,
-            fragment: target.fragment
-          }
+        cond do
+          String.starts_with?(dest_path, "/") ->
+            %URI{
+              path: dest_path,
+              query: target.query,
+              fragment: target.fragment
+            }
+
+          String.ends_with?(path, "/") ->
+            %URI{
+              path: Path.join(base_path, dest_path),
+              query: target.query,
+              fragment: target.fragment
+            }
+
+          true ->
+            %URI{
+              path: Path.join(Path.dirname(base_path), dest_path),
+              query: target.query,
+              fragment: target.fragment
+            }
         end
 
       # target is absolute.


### PR DESCRIPTION
Hi there! Thanks for the work on this library!

I am new to using JSON schemas, so I am not completely familiar with the details of the specs, but some JSON schemas that I am working with lately have had an `$id` field as a relative URI starting with a slash `/` with additional slashes (e.g. `/foods/apple`). In the `Exonerate.Context.id_swap_with/5` function, the `updated_resource` variable merges the `id` (`/foods/apple`) with the resource (`/foods/apple`) erroneously resulting in `/foods/foods/apple` and then crashing when it cannot find `/foods/foods/apple` in the ets table.

This change updates the extended `URI.merge` function on a relative URL to include expected behavior when the `dest_path` starts with a slash `/`, which is to completely replace the path with the `dest_path`. Example from the standard `URI.merge` function:

```
"https://example.com/hello/world" |> URI.parse() |> URI.merge("/food/apples")
%URI{
  scheme: "https",
  authority: "example.com",
  userinfo: nil,
  host: "example.com",
  port: 443,
  path: "/food/apples",
  query: nil,
  fragment: nil
}
```

I would like to add a unit test for this change as well, but I could use some help if possible.

Thanks again, and let me know how I can help.