### PR TITLE
Compile cleanly on Elixir 1.20 (warnings-as-errors)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ end
 
 ```elixir
 iex> SchemaModule.validate_input("some string")
-{:error, error_value: "some string", instance_location: "/", absolute_keyword_location: "#/type"}
+{:error, error_value: "some string", instance_location: "/", absolute_keyword_location: "#/type", expected: "object"}
 
 iex> SchemaModule.validate_input(%{"parameter" => "2"})
-{:error, error_value: "2", instance_location: "/parameter", absolute_keyword_location: "#/properties/parameter/type"}
+{:error, error_value: "2", instance_location: "/parameter", absolute_keyword_location: "#/properties/parameter/type", expected: "integer"}
 
 iex> SchemaModule.validate_input(%{"parameter" => 2})
 :ok

--- a/VERSIONS
+++ b/VERSIONS
@@ -102,3 +102,13 @@
 - updates to match_spec 1.0.0
 - makes Jason optional, preferring built-in JSON module (Elixir 1.18+)
 - moves Bowtie test harness to test/support
+
+# 1.2.2
+- Elixir 1.20 type-checker cleanliness (compiles with --warnings-as-errors):
+  - mark generated object-iterator functions `generated: true` so unreachable
+    error clauses in infallible-filter schemas aren't flagged redundant
+  - drop a redundant `is_list/1` guard in the format filter
+  - remove a dead `is_charlist?([])` clause (empty list handled by the caller)
+  - group `build_filter/4` clauses in the uniqueItems filter
+- move `preferred_cli_env` into `def cli` (Mix deprecation)
+- update stale README error-tuple examples (now include `expected:`)

--- a/lib/exonerate/filter/format.ex
+++ b/lib/exonerate/filter/format.ex
@@ -271,8 +271,8 @@ defmodule Exonerate.Filter.Format do
     opts = Keyword.get(opts, :format)
 
     if is_list(opts) do
-      types = List.wrap(if is_list(opts), do: opts[:types])
-      pointers = List.wrap(if is_list(opts), do: opts[:at])
+      types = List.wrap(opts[:types])
+      pointers = List.wrap(opts[:at])
 
       uri =
         pointer

--- a/lib/exonerate/filter/unique_items.ex
+++ b/lib/exonerate/filter/unique_items.ex
@@ -45,6 +45,8 @@ defmodule Exonerate.Filter.UniqueItems do
     end
   end
 
+  defp build_filter(_, _, _, _), do: []
+
   defmacro next_unique(resource, pointer, unique_items, item, _opts) do
     # TODO: let this be generalizable to xor_filter
     __CALLER__
@@ -63,6 +65,4 @@ defmodule Exonerate.Filter.UniqueItems do
         []
     end
   end
-
-  defp build_filter(_, _, _, _), do: []
 end

--- a/lib/exonerate/tools.ex
+++ b/lib/exonerate/tools.ex
@@ -386,8 +386,9 @@ defmodule Exonerate.Tools do
   defp convert_yaml_value(nil), do: nil
   defp convert_yaml_value(value) when is_atom(value), do: Atom.to_string(value)
 
-  # Check if a list is a charlist (string of integers)
-  defp is_charlist?([]), do: false
+  # Check if a list is a charlist (string of integers). The empty-list case is
+  # handled by the caller's cond (value == []) before this is reached, so no []
+  # clause here (it would be dead code).
   defp is_charlist?(list) when is_list(list), do: List.ascii_printable?(list)
   defp is_charlist?(_), do: false
 

--- a/lib/exonerate/type/object/iterator.ex
+++ b/lib/exonerate/type/object/iterator.ex
@@ -100,7 +100,12 @@ defmodule Exonerate.Type.Object.Iterator do
           ]
         end
 
-    quote do
+    # generated: true — for some schemas every filter is provably infallible, so
+    # the error-handling clauses are unreachable for that specialization and the
+    # Elixir (>= 1.20) type checker flags them redundant. They are still needed
+    # for fallible schemas, so mark the generated code as compiler-generated to
+    # suppress the false-positive warning. See E-xyza/Exonerate#87.
+    quote generated: true do
       defp unquote(call)(object, path, seen) do
         require Exonerate.Tools
 
@@ -124,7 +129,7 @@ defmodule Exonerate.Type.Object.Iterator do
   end
 
   defp build_seen(call, visitor_call, filters, _) do
-    quote do
+    quote generated: true do
       defp unquote(call)(object, path, seen) do
         require Exonerate.Tools
 
@@ -200,7 +205,10 @@ defmodule Exonerate.Type.Object.Iterator do
         end
       end
 
-    quote do
+    # generated: true — see build_seen/4 above: error clauses are unreachable for
+    # infallible-filter schemas but needed otherwise; suppress the type checker's
+    # false-positive redundancy warning. See E-xyza/Exonerate#87.
+    quote generated: true do
       defp unquote(call)(object, path) do
         require Exonerate.Tools
 
@@ -225,7 +233,9 @@ defmodule Exonerate.Type.Object.Iterator do
   end
 
   defp build_tracked(call, filters) do
-    quote do
+    # generated: true — see build_seen/4: suppress the type checker's
+    # false-positive redundant-error-clause warning. See E-xyza/Exonerate#87.
+    quote generated: true do
       defp unquote(call)(object, path) do
         require Exonerate.Tools
 
@@ -255,7 +265,9 @@ defmodule Exonerate.Type.Object.Iterator do
   end
 
   defp build_trivial(call, filters) do
-    quote do
+    # generated: true — see build_seen/4: suppress the type checker's
+    # false-positive redundant-error-clause warning. See E-xyza/Exonerate#87.
+    quote generated: true do
       defp unquote(call)(object, path) do
         require Exonerate.Tools
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Exonerate.MixProject do
   def project do
     [
       app: :exonerate,
-      version: "1.2.1",
+      version: "1.2.2",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -23,15 +23,20 @@ defmodule Exonerate.MixProject do
         extras: ["guides/formatting.md"],
         groups_for_extras: [Guides: ~r/guides\/.*/]
       ],
-      preferred_cli_env: [
+      test_coverage: [
+        ignore_modules: [SchemaModule, ExonerateTest.Automate, Exonerate.Cache.Resource]
+      ]
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: [
         bench_lib: :bench,
         gpt4_helper: :bench,
         gpt_fetch: :bench,
         find_by_resource: :test,
         "bowtie.harness": :test
-      ],
-      test_coverage: [
-        ignore_modules: [SchemaModule, ExonerateTest.Automate, Exonerate.Cache.Resource]
       ]
     ]
   end


### PR DESCRIPTION
Elixir 1.20's whole-program type inference flags several clauses in exonerate as redundant/unreachable, breaking the `warnings_as_errors: true` build. Address each:

- Object iterator codegen (type/object/iterator.ex): for schemas whose filters are provably infallible, the generated error-handling clauses are unreachable, but they are still required for fallible schemas. Mark the generated defp functions `quote generated: true` so the checker does not emit redundant-clause warnings against generated code.
- Format filter: drop a redundant inner `is_list/1` guard already established by the enclosing `if is_list(opts)`.
- Tools.is_charlist?/1: remove the dead `[]` clause — the only caller (convert_yaml_value/1) handles the empty list in its cond before this is reached.
- uniqueItems filter: group the two `build_filter/4` clauses.

Also move `preferred_cli_env` into `def cli` (Mix deprecation) and update the README's error-tuple examples, which were missing the `expected:` field the type filter now emits.

Bumps version to 1.2.2. Full suite: 4209 tests pass, 0 warnings.